### PR TITLE
Improve summarization screen

### DIFF
--- a/README_DEV.md
+++ b/README_DEV.md
@@ -5,7 +5,7 @@ This repository contains a minimal React Native skeleton implementing the basic 
 ## Available Screens
 
 - **Home** – navigation entry point.
-- **Summarize** – allows text input and sends it to the OpenAI API for summarization.
+- **Summarize** – allows text or a URL input, with options for summary length and bullet formatting, then sends it to the OpenAI API.
 - **Tasks** – local task list management.
 - **Chat** – simple chat interface powered by the OpenAI API.
 

--- a/src/screens/ChatScreen.js
+++ b/src/screens/ChatScreen.js
@@ -13,7 +13,7 @@ export default function ChatScreen() {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        Authorization: `Bearer YOUR_OPENAI_KEY`,
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
       },
       body: JSON.stringify({
         model: 'gpt-3.5-turbo',

--- a/src/screens/SummarizeScreen.js
+++ b/src/screens/SummarizeScreen.js
@@ -1,21 +1,42 @@
 import React, { useState } from 'react';
-import { View, TextInput, Button, Text, StyleSheet } from 'react-native';
+import { View, TextInput, Button, Text, StyleSheet, Switch } from 'react-native';
 
 export default function SummarizeScreen() {
   const [text, setText] = useState('');
   const [summary, setSummary] = useState('');
+  const [url, setUrl] = useState('');
+  const [numSentences, setNumSentences] = useState('3');
+  const [bullets, setBullets] = useState(false);
 
   async function summarize() {
-    // Placeholder call to OpenAI API
+    let targetText = text;
+    if (url) {
+      try {
+        const res = await fetch(url);
+        targetText = await res.text();
+      } catch (e) {
+        setSummary('Failed to fetch URL');
+        return;
+      }
+    }
+
+    const lengthPrompt = `in about ${numSentences} sentences`;
+    const stylePrompt = bullets ? 'Use bullet points.' : '';
+
     const response = await fetch('https://api.openai.com/v1/chat/completions', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        Authorization: `Bearer YOUR_OPENAI_KEY`,
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
       },
       body: JSON.stringify({
         model: 'gpt-3.5-turbo',
-        messages: [{ role: 'user', content: `Summarize: ${text}` }],
+        messages: [
+          {
+            role: 'user',
+            content: `Summarize the following text ${lengthPrompt}. ${stylePrompt}\n\n${targetText}`,
+          },
+        ],
       }),
     });
     const data = await response.json();
@@ -26,11 +47,28 @@ export default function SummarizeScreen() {
     <View style={styles.container}>
       <TextInput
         style={styles.input}
+        placeholder="Optional URL to fetch"
+        value={url}
+        onChangeText={setUrl}
+      />
+      <TextInput
+        style={styles.input}
         multiline
         placeholder="Enter text to summarize"
         value={text}
         onChangeText={setText}
       />
+      <TextInput
+        style={styles.singleLine}
+        keyboardType="number-pad"
+        placeholder="Number of sentences"
+        value={numSentences}
+        onChangeText={setNumSentences}
+      />
+      <View style={styles.switchRow}>
+        <Text>Bullet Points</Text>
+        <Switch value={bullets} onValueChange={setBullets} />
+      </View>
       <Button title="Summarize" onPress={summarize} />
       <Text style={styles.result}>{summary}</Text>
     </View>
@@ -49,6 +87,17 @@ const styles = StyleSheet.create({
     padding: 10,
     borderRadius: 4,
     height: 100,
+  },
+  singleLine: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 10,
+    borderRadius: 4,
+  },
+  switchRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
   },
   result: {
     marginTop: 20,


### PR DESCRIPTION
## Summary
- enhance README with summarization screen description
- expand Summarize screen with URL fetch, length and bullet options
- load API key from environment for chat and summarize

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_685127a3cc20832da9944ed9ff99a785