### PR TITLE
Add voice-enabled chatbot with persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Based on validated insights from Phase 1, the focus shifts to building the core 
 1. **Core Features (MVP):**
     - **AI-powered Text Summarization:** Ability to summarize articles, emails, web pages, and documents.
     - **Basic Task Management:** Features to create, assign, prioritize, and track tasks.
-    - **Simple AI Chatbot:** A conversational interface for answering general queries and providing quick information.
+    - **Simple AI Chatbot:** A conversational interface for answering general queries and providing quick information. Voice input and spoken replies enhance interaction, while conversation context is stored locally for continuity.
     - **Intuitive UI/UX:** Prioritize a seamless and intuitive onboarding process, clean design, and easy navigation to ensure high user retention from the start.
     - **Cross-Platform Compatibility:** Initial development targeting both iOS and Android platforms to maximize reach.
 2. **Technology Stack:**

--- a/README_DEV.md
+++ b/README_DEV.md
@@ -7,11 +7,11 @@ This repository contains a minimal React Native skeleton implementing the basic 
 - **Home** – navigation entry point.
 - **Summarize** – allows text or a URL input, with options for summary length and bullet formatting, then sends it to the OpenAI API.
 - **Tasks** – local task list management.
-- **Chat** – simple chat interface powered by the OpenAI API.
+- **Chat** – conversational co-pilot with optional voice input and spoken replies.
 
 ## Setup
 
-1. Install dependencies with `npm install` (requires Node.js and React Native CLI).
+1. Install dependencies with `npm install` (requires Node.js and React Native CLI). The chat screen uses `react-native-voice`, `react-native-tts` and `@react-native-async-storage/async-storage` for speech and persistence.
 2. Copy `.env.example` to `.env` and add your `OPENAI_API_KEY`.
 3. Run the Metro bundler with `npm start` and launch on a simulator or device using `npm run ios` or `npm run android`.
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
     "react": "18.2.0",
     "react-native": "0.72.4",
     "@react-navigation/native": "^6.1.6",
-    "@react-navigation/native-stack": "^6.9.12"
+    "@react-navigation/native-stack": "^6.9.12",
+    "react-native-voice": "^3.2.1",
+    "react-native-tts": "^5.0.0",
+    "@react-native-async-storage/async-storage": "^1.20.1"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/src/screens/ChatScreen.js
+++ b/src/screens/ChatScreen.js
@@ -1,9 +1,34 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { View, TextInput, Button, FlatList, Text, StyleSheet } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import Voice from 'react-native-voice';
+import Tts from 'react-native-tts';
 
 export default function ChatScreen() {
   const [input, setInput] = useState('');
   const [messages, setMessages] = useState([]);
+  const [isRecording, setIsRecording] = useState(false);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const data = await AsyncStorage.getItem('chat_messages');
+        if (data) setMessages(JSON.parse(data));
+      } catch (e) {
+        console.warn('Failed to load messages');
+      }
+    }
+    load();
+    return () => {
+      Voice.destroy().then(Voice.removeAllListeners);
+    };
+  }, []);
+
+  useEffect(() => {
+    AsyncStorage.setItem('chat_messages', JSON.stringify(messages)).catch(() => {
+      console.warn('Failed to save messages');
+    });
+  }, [messages]);
 
   async function sendMessage() {
     const userMessage = { id: Date.now().toString(), role: 'user', content: input };
@@ -23,6 +48,29 @@ export default function ChatScreen() {
     const data = await response.json();
     const aiMessage = { id: Date.now().toString() + '-ai', role: 'ai', content: data.choices?.[0]?.message?.content || '' };
     setMessages(prev => [...prev, aiMessage]);
+    Tts.speak(aiMessage.content);
+  }
+
+  async function startRecording() {
+    try {
+      Voice.onSpeechResults = (e) => {
+        const text = e.value?.[0] || '';
+        setInput(text);
+      };
+      setIsRecording(true);
+      await Voice.start('en-US');
+    } catch (e) {
+      console.warn('Voice start error', e);
+    }
+  }
+
+  async function stopRecording() {
+    try {
+      await Voice.stop();
+    } catch (e) {
+      console.warn('Voice stop error', e);
+    }
+    setIsRecording(false);
   }
 
   return (
@@ -42,6 +90,7 @@ export default function ChatScreen() {
           onChangeText={setInput}
           placeholder="Type a message"
         />
+        <Button title={isRecording ? "Stop" : "Voice"} onPress={isRecording ? stopRecording : startRecording} />
         <Button title="Send" onPress={sendMessage} />
       </View>
     </View>
@@ -51,7 +100,7 @@ export default function ChatScreen() {
 const styles = StyleSheet.create({
   container: { flex: 1, padding: 16 },
   list: { flex: 1 },
-  row: { flexDirection: 'row', alignItems: 'center' },
+  row: { flexDirection: 'row', alignItems: 'center', gap: 10 },
   input: { flex: 1, borderWidth: 1, borderColor: '#ccc', padding: 10, borderRadius: 4, marginRight: 10 },
   userText: { alignSelf: 'flex-end', backgroundColor: '#DCF8C6', padding: 6, marginVertical: 4, borderRadius: 4 },
   aiText: { alignSelf: 'flex-start', backgroundColor: '#EEE', padding: 6, marginVertical: 4, borderRadius: 4 },


### PR DESCRIPTION
## Summary
- enable basic chat context storage via AsyncStorage
- add voice input and text-to-speech replies using `react-native-voice` and `react-native-tts`
- document updated Chat screen setup and features

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685129228360832d950a3d1f6f475bf0