### PR TITLE
Add OAuth-based integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ Based on validated insights from Phase 1, the focus shifts to building the core 
     - **AI/ML Integration:** Leverage existing large language model (LLM) APIs (e.g., OpenAI, Google Gemini) for generative AI capabilities, focusing on how the app's user experience and workflow differentiate it .
 3. **Monetization Integration (MVP):** Implement the freemium model with clear, contextual upgrade paths to the "Synapse Pro" subscription tier, highlighting the additional benefits of premium features.
 4. **Testing & Refinement:** Rigorous internal quality assurance and a closed beta program with a select group of early sign-ups from Phase 1. This allows for gathering detailed user feedback, identifying bugs, and refining features before public launch.
+### Pro/Premium Feature: Third-Party Application Integration
+
+Synapse Pro and Premium unlock seamless connections with services like Google Calendar, Outlook, Dropbox, Google Drive, Slack, Microsoft Teams and popular email providers. OAuth 2.0 authentication keeps user data secure while the app syncs events, files and conversations in near real time. Users can create tasks from emails, summarize cloud documents and manage messaging threads without leaving Synapse AI.
+
 
 ### Phase 3: Launch and Post-Launch Strategy
 

--- a/README_DEV.md
+++ b/README_DEV.md
@@ -15,4 +15,7 @@ This repository contains a minimal React Native skeleton implementing the basic 
 2. Copy `.env.example` to `.env` and add your `OPENAI_API_KEY`.
 3. Run the Metro bundler with `npm start` and launch on a simulator or device using `npm run ios` or `npm run android`.
 
+
 This code is provided as a starting point and is not production ready.
+
+The `src/integrations` directory now provides OAuth-based clients for services such as Google, Outlook, Dropbox, Google Drive, Slack, Teams and email. Each integration exposes `authenticate`, `fetchData` and `pushData` helpers for obtaining tokens and interacting with the respective APIs.

--- a/package.json
+++ b/package.json
@@ -13,9 +13,10 @@
     "react-native": "0.72.4",
     "@react-navigation/native": "^6.1.6",
     "@react-navigation/native-stack": "^6.9.12",
-    "react-native-voice": "^3.2.1",
-    "react-native-tts": "^5.0.0",
-    "@react-native-async-storage/async-storage": "^1.20.1"
+    "react-native-voice": "^0.3.0",
+    "react-native-tts": "^4.1.1",
+    "@react-native-async-storage/async-storage": "^1.20.1",
+    "nodemailer": "^6.9.11"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/src/integrations/baseService.js
+++ b/src/integrations/baseService.js
@@ -1,0 +1,82 @@
+import { URLSearchParams } from 'url';
+
+export default function createService({ name, authUrl, tokenUrl, baseUrl }) {
+  async function getAuthUrl({ clientId, redirectUri, scopes = [], state = '' }) {
+    const params = new URLSearchParams({
+      response_type: 'code',
+      client_id: clientId,
+      redirect_uri: redirectUri,
+      scope: scopes.join(' '),
+      state,
+      access_type: 'offline',
+    });
+    return `${authUrl}?${params.toString()}`;
+  }
+
+  async function authenticate({ clientId, clientSecret, redirectUri, code, refreshToken }) {
+    const params = new URLSearchParams({
+      client_id: clientId,
+      client_secret: clientSecret,
+      redirect_uri: redirectUri,
+    });
+
+    if (code) {
+      params.set('grant_type', 'authorization_code');
+      params.set('code', code);
+    } else if (refreshToken) {
+      params.set('grant_type', 'refresh_token');
+      params.set('refresh_token', refreshToken);
+    } else {
+      throw new Error('code or refreshToken required');
+    }
+
+    const res = await fetch(tokenUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: params.toString(),
+    });
+
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`[${name}] auth failed: ${res.status} ${text}`);
+    }
+
+    return res.json();
+  }
+
+  async function request(token, endpoint, { method = 'GET', params, body } = {}) {
+    const url = new URL(endpoint, baseUrl);
+    if (params) {
+      Object.keys(params).forEach(key => {
+        if (params[key] !== undefined) url.searchParams.set(key, params[key]);
+      });
+    }
+
+    const res = await fetch(url.toString(), {
+      method,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: body ? JSON.stringify(body) : undefined,
+    });
+
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`[${name}] request failed: ${res.status} ${text}`);
+    }
+
+    if (res.status === 204) return null;
+    return res.json();
+  }
+
+  function fetchData(token, endpoint, params) {
+    return request(token, endpoint, { params });
+  }
+
+  function pushData(token, endpoint, body, method = 'POST') {
+    return request(token, endpoint, { method, body });
+  }
+
+  return { getAuthUrl, authenticate, fetchData, pushData };
+}

--- a/src/integrations/drive.js
+++ b/src/integrations/drive.js
@@ -1,0 +1,10 @@
+import createService from './baseService';
+
+const service = createService({
+  name: 'drive',
+  authUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
+  tokenUrl: 'https://oauth2.googleapis.com/token',
+  baseUrl: 'https://www.googleapis.com/drive/v3/',
+});
+
+export default service;

--- a/src/integrations/dropbox.js
+++ b/src/integrations/dropbox.js
@@ -1,0 +1,10 @@
+import createService from './baseService';
+
+const service = createService({
+  name: 'dropbox',
+  authUrl: 'https://www.dropbox.com/oauth2/authorize',
+  tokenUrl: 'https://api.dropboxapi.com/oauth2/token',
+  baseUrl: 'https://api.dropboxapi.com/2/',
+});
+
+export default service;

--- a/src/integrations/email.js
+++ b/src/integrations/email.js
@@ -1,0 +1,18 @@
+import nodemailer from 'nodemailer';
+
+export async function authenticate(config = {}) {
+  const transporter = nodemailer.createTransport(config);
+  await transporter.verify();
+  return transporter;
+}
+
+export async function fetchData(/* transporter, params */) {
+  throw new Error('fetchData not implemented for email integration');
+}
+
+export async function pushData(transporter, mailOptions) {
+  await transporter.sendMail(mailOptions);
+  return { success: true };
+}
+
+export default { authenticate, fetchData, pushData };

--- a/src/integrations/google.js
+++ b/src/integrations/google.js
@@ -1,0 +1,10 @@
+import createService from './baseService';
+
+const service = createService({
+  name: 'google',
+  authUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
+  tokenUrl: 'https://oauth2.googleapis.com/token',
+  baseUrl: 'https://www.googleapis.com/',
+});
+
+export default service;

--- a/src/integrations/index.js
+++ b/src/integrations/index.js
@@ -1,0 +1,7 @@
+export { default as google } from './google';
+export { default as outlook } from './outlook';
+export { default as dropbox } from './dropbox';
+export { default as drive } from './drive';
+export { default as slack } from './slack';
+export { default as teams } from './teams';
+export { default as email } from './email';

--- a/src/integrations/outlook.js
+++ b/src/integrations/outlook.js
@@ -1,0 +1,10 @@
+import createService from './baseService';
+
+const service = createService({
+  name: 'outlook',
+  authUrl: 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize',
+  tokenUrl: 'https://login.microsoftonline.com/common/oauth2/v2.0/token',
+  baseUrl: 'https://graph.microsoft.com/v1.0/',
+});
+
+export default service;

--- a/src/integrations/slack.js
+++ b/src/integrations/slack.js
@@ -1,0 +1,10 @@
+import createService from './baseService';
+
+const service = createService({
+  name: 'slack',
+  authUrl: 'https://slack.com/oauth/v2/authorize',
+  tokenUrl: 'https://slack.com/api/oauth.v2.access',
+  baseUrl: 'https://slack.com/api/',
+});
+
+export default service;

--- a/src/integrations/teams.js
+++ b/src/integrations/teams.js
@@ -1,0 +1,10 @@
+import createService from './baseService';
+
+const service = createService({
+  name: 'teams',
+  authUrl: 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize',
+  tokenUrl: 'https://login.microsoftonline.com/common/oauth2/v2.0/token',
+  baseUrl: 'https://graph.microsoft.com/v1.0/',
+});
+
+export default service;


### PR DESCRIPTION
## Summary
- implement OAuth helpers in `baseService`
- provide Google, Outlook, Dropbox, Drive, Slack and Teams clients
- add email integration using nodemailer
- update developer docs and dependencies

## Testing
- `npm install`
- `npm test` *(fails: no tests defined)*

------
https://chatgpt.com/codex/tasks/task_e_68512afe5998832dbeba2f898768191d