### PR TITLE
Add proactive premium insights

### DIFF
--- a/App.js
+++ b/App.js
@@ -5,6 +5,7 @@ import HomeScreen from './src/screens/HomeScreen';
 import SummarizeScreen from './src/screens/SummarizeScreen';
 import TasksScreen from './src/screens/TasksScreen';
 import ChatScreen from './src/screens/ChatScreen';
+import PremiumScreen from './src/screens/PremiumScreen';
 
 const Stack = createNativeStackNavigator();
 
@@ -16,6 +17,7 @@ export default function App() {
         <Stack.Screen name="Summarize" component={SummarizeScreen} />
         <Stack.Screen name="Tasks" component={TasksScreen} />
         <Stack.Screen name="Chat" component={ChatScreen} />
+        <Stack.Screen name="Premium" component={PremiumScreen} />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ Based on validated insights from Phase 1, the focus shifts to building the core 
 
 Synapse Pro and Premium unlock seamless connections with services like Google Calendar, Outlook, Dropbox, Google Drive, Slack, Microsoft Teams and popular email providers. OAuth 2.0 authentication keeps user data secure while the app syncs events, files and conversations in near real time. Users can create tasks from emails, summarize cloud documents and manage messaging threads without leaving Synapse AI.
 
+### Premium Feature: Proactive AI Insights and Automation
+
+Synapse Premium adds a proactive layer to the co-pilot experience. Leveraging integrated data and generative AI, the app can analyze upcoming deadlines and communications to surface intelligent meeting prep summaries, personalized learning suggestions and workflow automations. A dedicated screen in the mobile app lets Premium users generate on-demand insights based on their current tasks and connected services.
+
 
 ### Phase 3: Launch and Post-Launch Strategy
 

--- a/README_DEV.md
+++ b/README_DEV.md
@@ -8,6 +8,7 @@ This repository contains a minimal React Native skeleton implementing the basic 
 - **Summarize** – allows text or a URL input, with options for summary length and bullet formatting, then sends it to the OpenAI API.
 - **Tasks** – intelligent task and project management with AI-powered prioritization, automatic breakdown of tasks, reminders and progress tracking.
 - **Chat** – conversational co-pilot with optional voice input and spoken replies.
+- **Premium** – generates proactive insights from your saved tasks using the OpenAI API.
 
 ## Setup
 

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -7,6 +7,7 @@ export default function HomeScreen({ navigation }) {
       <Button title="Summarize" onPress={() => navigation.navigate('Summarize')} />
       <Button title="Tasks" onPress={() => navigation.navigate('Tasks')} />
       <Button title="Chat" onPress={() => navigation.navigate('Chat')} />
+      <Button title="Premium" onPress={() => navigation.navigate('Premium')} />
     </View>
   );
 }

--- a/src/screens/PremiumScreen.js
+++ b/src/screens/PremiumScreen.js
@@ -1,0 +1,50 @@
+import React, { useState, useEffect } from 'react';
+import { View, Button, Text, StyleSheet } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export default function PremiumScreen() {
+  const [insights, setInsights] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [tasks, setTasks] = useState([]);
+
+  useEffect(() => {
+    AsyncStorage.getItem('tasks').then(d => {
+      if (d) setTasks(JSON.parse(d));
+    });
+  }, []);
+
+  async function generateInsights() {
+    setLoading(true);
+    try {
+      const prompt = `Provide proactive productivity suggestions based on these tasks: ${tasks.map(t => t.title).join(', ')}.`;
+      const res = await fetch('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+        },
+        body: JSON.stringify({
+          model: 'gpt-3.5-turbo',
+          messages: [{ role: 'user', content: prompt }],
+        }),
+      });
+      const data = await res.json();
+      setInsights(data.choices?.[0]?.message?.content || 'No insights');
+    } catch (e) {
+      setInsights('Failed to generate insights');
+    }
+    setLoading(false);
+  }
+
+  return (
+    <View style={styles.container}>
+      <Button title="Generate Insights" onPress={generateInsights} disabled={loading} />
+      <Text style={styles.text}>{insights}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 16, gap: 10 },
+  text: { marginTop: 20 },
+});


### PR DESCRIPTION
## Summary
- create a new `PremiumScreen` that uses OpenAI to generate suggestions
- link Premium screen in navigation and home page
- document Premium insights feature in README
- mention the Premium screen in developer README

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68512e457768832d904a3f743d8cb441